### PR TITLE
fix deprecated numpy.complex

### DIFF
--- a/igor/binarywave.py
+++ b/igor/binarywave.py
@@ -107,7 +107,7 @@ class NullStaticStringField (StaticStringField):
 # From IgorMath.h
 TYPE_TABLE = {        # (key: integer flag, value: numpy dtype)
     0:None,           # Text wave, not handled in ReadWave.c
-    1:_numpy.complex, # NT_CMPLX, makes number complex.
+    1:complex, # NT_CMPLX, makes number complex.
     2:_numpy.float32, # NT_FP32, 32 bit fp numbers.
     3:_numpy.complex64,
     4:_numpy.float64, # NT_FP64, 64 bit fp numbers.


### PR DESCRIPTION
Current version of numpy deprecates the use of numpy.complex, as the builtin complex substitutes it. This PR fixes this small bug